### PR TITLE
fix: 🐛 async action type

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,13 +5,13 @@ export function generateTxId(): string {
 }
 
 export async function asyncActionWithLogging<TResult = unknown>(
-  fn: Promise<TResult>,
+  fn: () => Promise<TResult>,
   onSuccess: (result: TResult) => void,
   onError: (err: unknown) => void,
   rethrow = true
 ) {
   try {
-    const result = await fn;
+    const result = await fn();
     onSuccess(result);
 
     return result;


### PR DESCRIPTION
## In this PR:

- Fix `asyncActionWithLogging` type that expected a promise instead of a function returning a promise, which makes code easier to read and write on the consumer applications.